### PR TITLE
Fix ootb webapp

### DIFF
--- a/arduino-iot-cloud-provisioning/openssl.conf
+++ b/arduino-iot-cloud-provisioning/openssl.conf
@@ -13,6 +13,6 @@ pkcs11 = pkcs11_section
 
 [pkcs11_section]
 engine_id = pkcs11
-dynamic_path = /usr/lib/engines-1.1/pkcs11.so
+dynamic_path = /usr/lib/engines-3/pkcs11.so
 MODULE_PATH = /usr/lib/libckteec.so.0
 init = 0

--- a/arduino-ootb-webapp/api/networking/ethernet.go
+++ b/arduino-ootb-webapp/api/networking/ethernet.go
@@ -3,6 +3,8 @@ package networking
 import (
 	"fmt"
 	"net"
+	"os"
+	"strings"
 	"time"
 	"x8-ootb/utils"
 
@@ -10,15 +12,65 @@ import (
 	"github.com/google/uuid"
 )
 
-const ETHERNET_INTERFACE_NAME = "eth0"
+// Default ethernet interface name. On newer LmP/Yocto images the on-board NIC
+// is renamed by systemd/udev to "end0" (or similar predictable name) instead of
+// "eth0". Use ResolveEthernetIface() to get the actual interface at runtime.
+const ETHERNET_INTERFACE_NAME_DEFAULT = "eth0"
 const ETHERNET_TYPE = "802-3-ethernet"
 
+// ResolveEthernetIface returns the name of the on-board ethernet interface.
+// Resolution order:
+//  1. environment variable ETHERNET_IFACE (explicit override)
+//  2. first physical ethernet device exposed by NetworkManager (skipping
+//     veth*, docker*, br-* virtual interfaces)
+//  3. fallback to "eth0" for backwards compatibility
+func ResolveEthernetIface() string {
+	if v := strings.TrimSpace(os.Getenv("ETHERNET_IFACE")); v != "" {
+		return v
+	}
+	if name := discoverEthernetIface(); name != "" {
+		return name
+	}
+	return ETHERNET_INTERFACE_NAME_DEFAULT
+}
+
+func discoverEthernetIface() string {
+	nm, err := gonetworkmanager.NewNetworkManager()
+	if err != nil {
+		return ""
+	}
+	devices, err := nm.GetDevices()
+	if err != nil {
+		return ""
+	}
+	for _, d := range devices {
+		dtype, err := d.GetPropertyDeviceType()
+		if err != nil || dtype != gonetworkmanager.NmDeviceTypeEthernet {
+			continue
+		}
+		name, err := d.GetPropertyInterface()
+		if err != nil || name == "" {
+			continue
+		}
+		// Skip virtual / container interfaces.
+		if strings.HasPrefix(name, "veth") ||
+			strings.HasPrefix(name, "docker") ||
+			strings.HasPrefix(name, "br-") ||
+			strings.HasPrefix(name, "br") && strings.Contains(name, "-") {
+			continue
+		}
+		return name
+	}
+	return ""
+}
+
 func GetEthernetConnection() (*Connection, error) {
-	return GetConnection(ETHERNET_INTERFACE_NAME)
+	return GetConnection(ResolveEthernetIface())
 }
 
 func EthConnect(payload EthConnection) error {
-	err := utils.DeleteConnectionByInterfaceName(ETHERNET_INTERFACE_NAME)
+	iface := ResolveEthernetIface()
+	err := utils.DeleteConnectionByInterfaceName(iface)
 	if err != nil {
 		return fmt.Errorf("cannot delete connection: %w", err)
 	}
@@ -39,7 +91,7 @@ func EthConnect(payload EthConnection) error {
 		return fmt.Errorf("cannot create uuid: %w", err)
 	}
 	connection["connection"]["uuid"] = connectionUUID.String()
-	connection["connection"]["interface-name"] = ETHERNET_INTERFACE_NAME
+	connection["connection"]["interface-name"] = iface
 	connection["connection"]["autoconnect"] = true
 
 	connection[ETHERNET_TYPE] = make(map[string]interface{})

--- a/arduino-ootb-webapp/api/networking/modem.go
+++ b/arduino-ootb-webapp/api/networking/modem.go
@@ -19,6 +19,20 @@ const MODEM_MODEL_EU = "EC200A"
 const MODEM_INTERFACE_NAME = "cdc-wdm0"
 const MODEM_INTERFACE_NAME_EU = "usb0"
 
+// isModemManagerUnavailable reports whether the given error originates from
+// the host's DBus refusing to activate ModemManager (e.g. when the service is
+// not installed on the OS image). In that case callers should behave as if no
+// modem is present, instead of bubbling up a noisy error.
+func isModemManagerUnavailable(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := err.Error()
+	return strings.Contains(msg, "org.freedesktop.ModemManager1") ||
+		strings.Contains(msg, "was not provided by any .service files") ||
+		strings.Contains(msg, "ServiceUnknown")
+}
+
 func GetModemConnection() (res *ModemConnection, err error) {
 	res = &ModemConnection{}
 	modem, _, err := GetModem()
@@ -247,10 +261,19 @@ func (m *ModemConnection) getSignal(rssi string, rsrq string) (err error) {
 func GetModem() (res modemmanager.Modem, manufacturer string, err error) {
 	mm, err := modemmanager.NewModemManager()
 	if err != nil {
+		if isModemManagerUnavailable(err) {
+			// ModemManager is not installed/active on the host: treat as
+			// "no modem" so the frontend gets a clean response and the log
+			// is not flooded with DBus activation errors.
+			return nil, "", nil
+		}
 		return nil, "", err
 	}
 	modems, err := mm.GetModems()
 	if err != nil {
+		if isModemManagerUnavailable(err) {
+			return nil, "", nil
+		}
 		return nil, "", err
 	}
 	if len(modems) == 0 {

--- a/arduino-ootb/docker-compose.yml
+++ b/arduino-ootb/docker-compose.yml
@@ -11,7 +11,7 @@ services:
     - NET_ADMIN
     environment:
     - 'DBUS_SYSTEM_BUS_ADDRESS=unix:path=/run/dbus/system_bus_socket'
-    - 'SSH_HOST=devel:22'
+    - 'SSH_HOST=python-devel:22'
     - 'SSH_USER=root'
     - 'SSH_KEY=/root/.ssh/id_rsa'
     - 'SSH_KEY_PUB=/root/.ssh/id_rsa.pub'


### PR DESCRIPTION

## Summary

The recent base-image bumps (alpine 3.15 → 3.21, golang 1.21 → 1.25, node 20 → 22) coincided with an updated LmP/Yocto OS on the Portenta X8 that broke two assumptions the webapp made about the host:

1. The on-board ethernet NIC is now exposed by systemd/udev as `end0` (predictable name) instead of the legacy `eth0`. Hardcoded lookups for `"eth0"` made NetworkManager return *"No device found for the requested iface"* on every poll.
2. ModemManager has been dropped from the new OS image. Every poll of the modem endpoint produced a noisy `lvl=eror` entry: *"The name org.freedesktop.ModemManager1 was not provided by any .service files"*.

## Changes

**`api/networking/ethernet.go`** — replaced the hardcoded `ETHERNET_INTERFACE_NAME = "eth0"` with a `ResolveEthernetIface()` helper that:
1. honors an explicit `ETHERNET_IFACE` env var (escape hatch);
2. otherwise auto-discovers the first physical ethernet device via NetworkManager (skipping `veth*`, `docker*`, `br-*`);
3. falls back to `eth0` to stay backwards compatible.

`GetEthernetConnection()` and `EthConnect()` now use the resolved name, so the same build works on both old (`eth0`) and new (`end0`, `enp*`, …) LmP images.

**`api/networking/modem.go`** — added `isModemManagerUnavailable(err)` to detect the DBus *"not provided by any .service files"* error. `GetModem()` now treats this as "no modem present" and returns `(nil, "", nil)`, falling through to the existing `"No Modem Found"` branch. No more error-level log floods, frontend gets a clean response.

A dynamic path in the openssl.conf was pointing to an old path "/usr/lib/engines-1.1/pkcs11.so", now updated to the correct path "/usr/lib/engines-3/pkcs11.so"

Side-finding during testing: the in-browser **Shell** feature is broken in the deployed compose because `SSH_HOST=devel:22` no longer resolves. The compose service was renamed from `devel` to `python-devel`, but the env var was never updated. Fix belongs to `arduino-ootb/docker-compose.yml` (re-add network alias `devel` to `python-devel`, or change the env var to `python-devel:22`) — separate PR.